### PR TITLE
Remove 'Unknown' from display

### DIFF
--- a/devicebatt.widget/index.coffee
+++ b/devicebatt.widget/index.coffee
@@ -28,7 +28,7 @@ style =
 	icon_keyboard:
 		png: "devicebatt.widget/PNG/keyboard-2-32.png"
 
-command: "system_profiler SPBluetoothDataType | grep -E 'Battery|Minor Type' | sed 's/Minor Type://g' | sed 's/Battery Level://g' | sed -e 's/^[ \t]*//' | paste -d' ' - -"
+command: "system_profiler SPBluetoothDataType | grep -E 'Battery|Minor Type' | sed 's/Minor Type://g' | sed 's/Battery Level://g' |sed 's/Unknown//g' |sed -e 's/^[ \t]*//' | paste -d' ' - -"
 
 refreshFrequency: (1000 * 3)
 


### PR DESCRIPTION
I'm not certain if it was device-specific for me, but I added a small additional `sed` cmd which removed the unwanted content from my screen.

If you know it's not applicable to others, feel free to close the PR. It might be worth mentioning in the docs if others have commented on seeing the same though. 
